### PR TITLE
Store run_at as iso8601 format

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -399,7 +399,7 @@ module Resque
     def working_on(job)
       data = encode \
         :queue   => job.queue,
-        :run_at  => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
+        :run_at  => Time.now.utc.iso8601,
         :payload => job.payload
       redis.set("worker:#{self}", data)
     end


### PR DESCRIPTION
Upstream already does this, and it makes deserializing the time not painful.

/cc @rtomayko 
