### PR TITLE
Backport passing Resque::Worker object to before_first_fork hook

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -243,7 +243,7 @@ module Resque
       enable_gc_optimizations
       register_signal_handlers
       prune_dead_workers
-      run_hook :before_first_fork
+      run_hook :before_first_fork, self
       register_worker
 
       # Fix buffering so we can `rake resque:work > resque.log` and


### PR DESCRIPTION
We are actively using this bit of code so I think we should merge it into our branch (I have a bit more cleanup coming too).

/cc @rtomayko @wfarr
