### PR TITLE
Add a `before_reserve` hook

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -121,6 +121,15 @@ module Resque
     @after_perform = after_perform
   end
 
+  # Runs before a worker reserves a job from a queue
+  def before_reserve(&block)
+    block ? (@before_reserve = block) : @before_reserve
+  end
+
+  # Set the before_reserve proc.
+  def before_reserve=(before_reserve)
+    @before_reserve = before_reserve
+  end
 
   def to_s
     "Resque Client connected to #{redis_id}"

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -19,7 +19,7 @@ module Resque
     # abort the job.
     DontPerform = Class.new(StandardError)
 
-    # Raise Rescue::Job::DontReserve from a before_reserve hook to
+    # Raise Resque::Job::DontReserve from a before_reserve hook to
     # stop the worker from taking a job from the queue.
     DontReserve = Class.new(StandardError)
 

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -19,7 +19,7 @@ module Resque
     # abort the job.
     DontPerform = Class.new(StandardError)
 
-    # Raise Rescue::Job::DontPerform from a before_reserve hook to
+    # Raise Rescue::Job::DontReserve from a before_reserve hook to
     # stop the worker from taking a job from the queue.
     DontReserve = Class.new(StandardError)
 


### PR DESCRIPTION
This is the stab at a `before_reserve` hook as suggested by @defunkt. I feel like this might be better one level up in `Worker` but this follows the pattern that this code base already is using.

This would allow someone to do...

```
Resque.before_reserve do |queue|
  raise Resque::Job::DontReserve if queue == "high"
end
```

cc @ymendel @tnm 
