### PR TITLE
Steal sismember reduction from latest resque 1.x

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -26,7 +26,7 @@ module Resque
 
     # Returns an array of all worker objects.
     def self.all
-      Array(redis.smembers(:workers)).map { |id| find(id) }.compact
+      Array(redis.smembers(:workers)).map { |id| find(id, true) }.compact
     end
 
     # Returns an array of all worker objects currently processing
@@ -51,13 +51,13 @@ module Resque
       end
 
       reportedly_working.keys.map do |key|
-        find key.sub("worker:", '')
+        find(key.sub("worker:", ''), true)
       end.compact
     end
 
     # Returns a single worker object. Accepts a string id.
-    def self.find(worker_id)
-      if exists? worker_id
+    def self.find(worker_id, skip_exists = false)
+      if skip_exists || exists?(worker_id)
         queues = worker_id.split(':')[-1].split(',')
         worker = new(*queues)
         worker.to_s = worker_id


### PR DESCRIPTION
Relevant commit:
https://github.com/resque/resque/commit/f1ecf8bd5a6960ba184158d4e3132189d21fabc0

There is literally no point in doing the exists? check in find when iterating the workers in all, since they are pulled from the same set.
