### PR TITLE
Too many workers to prune the set

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -244,7 +244,6 @@ module Resque
     def startup
       enable_gc_optimizations
       register_signal_handlers
-      prune_dead_workers
       run_hook :before_first_fork, self
       register_worker
 


### PR DESCRIPTION
We are hitting contention and timeouts as the number of workers increase.

Let’s reduce the contention on the members set by reducing the number of processes trying to manage it concurrently. This PR will pair with a PR inside `github/github` which will prune the member set in the before_fork of the resqued process. :soon:

@github/high-availability cc @github/background-jobs @piki 