### PR TITLE
Split queue information out of worker ID

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -362,7 +362,6 @@ module Resque
     # lifecycle on startup.
     def register_worker
       redis.sadd(:workers, self)
-      started!
       redis.set("worker:#{self}:queues", @queues.join(","))
     end
 
@@ -390,7 +389,6 @@ module Resque
 
       redis.srem(:workers, self)
       redis.del("worker:#{self}")
-      redis.del("worker:#{self}:started")
       redis.del("worker:#{self}:queues")
 
       Stat.clear("processed:#{self}")
@@ -434,16 +432,6 @@ module Resque
     def failed!
       Stat << "failed"
       Stat << "failed:#{self}"
-    end
-
-    # What time did this worker start? Returns an instance of `Time`
-    def started
-      redis.get "worker:#{self}:started"
-    end
-
-    # Tell Redis we've started
-    def started!
-      redis.set("worker:#{self}:started", Time.now.to_s)
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -394,9 +394,6 @@ module Resque
         redis.del("worker:#{self}")
         redis.del("worker:#{self}:queues")
       end
-
-      Stat.clear("processed:#{self}")
-      Stat.clear("failed:#{self}")
     end
 
     # Given a job, tells Redis we're working on it. Useful for seeing
@@ -416,26 +413,14 @@ module Resque
       redis.del("worker:#{self}")
     end
 
-    # How many jobs has this worker processed? Returns an int.
-    def processed
-      Stat["processed:#{self}"]
-    end
-
     # Tell Redis we've processed a job.
     def processed!
       Stat << "processed"
-      Stat << "processed:#{self}"
-    end
-
-    # How many failed jobs has this worker seen? Returns an int.
-    def failed
-      Stat["failed:#{self}"]
     end
 
     # Tells Redis we've failed a job.
     def failed!
       Stat << "failed"
-      Stat << "failed:#{self}"
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.


### PR DESCRIPTION
This is followup from #9.

 Resque workers are currently identified by the triplet of `hostname:pid:queues`. However, many of our workers are using very large queue lists, resulting in worker ids that are 500 bytes or more. Instead of storing the list of queues in the worker id, move the queues to a separate key. The keys are used as members of the `resque:workers` set for bookkeeping, and as a part of a `resque:worker:<id>` key to log that a worker is currently processing a job.

The hope is that the smaller keys will reduce contention on the `resque:workers` set by making the keys smaller, in hopes that smaller keys will result in faster performance both for adding/removing members as well as the overall size of the data required to send the entire list of workers via SMEMBERS.

The list of queues is preserved in a separate key for use with debugging tools like `gh-resque`.

I've also removed the `resque:worker:<id>:started` key, which tracked when a worker started, and wasn't used anywhere.

Smaller ids result in keys that are closer to 50 bytes instead of ~500 bytes, which might help redis set performance. From [the redis manual](https://redis.io/topics/data-types-intro):

> Very long keys are not a good idea. For instance a key of 1024 bytes is a bad idea not only memory-wise, but also because the lookup of the key in the dataset may require several costly key-comparisons. Even when the task at hand is to match the existence of a large value, hashing it (for example with SHA1) is a better idea, especially from the perspective of memory and bandwidth.

Based on the SHA1 suggestion, which is a 40-byte string, cutting the id size might be a big help.

This requires a followup PR in github/github.

cc @ammeep @github/high-availability and @github/background-jobs 