### PR TITLE
Use BLPOP to reserve jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,12 @@ source :rubygems
 gemspec
 
 group :test do
+  gem "test-unit-minitest"
   gem "rake"
   gem "rack-test", "~> 0.5"
   gem "mocha", "~> 0.9.7"
   gem "leftright", :platforms => :mri_18
   gem "yajl-ruby", "~>1.1.0", :platforms => :mri
   gem "json", "~>1.5.3", :platforms => [:jruby, :rbx]
-  gem "hoptoad_notifier"
-  gem "airbrake"
   gem "i18n"
 end

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -337,12 +337,12 @@ module Resque
   #
   # queues  - An Array of String queue names to check
   # timeout - Integer number of seconds to block when retrieving jobs.
-  #           Defaults to 1.
+  #           Defaults to 5.
   #
   # Returns a Resque::Job or falsey.
   #
   # This method is considered part of the `stable` API.
-  def reserve(queues, timeout=1)
+  def reserve(queues, timeout=5)
     Job.reserve(Array(queues), timeout)
   end
 

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -173,9 +173,13 @@ module Resque
 
   # Pops a job off a queue. Queue name should be a string.
   #
-  # Returns a Ruby object.
-  def pop(queue)
-    decode redis.lpop("queue:#{queue}")
+  # Returns an array of [queue_name, decoded_payload], or falsey.
+  def pop(*queues)
+    queue_names = queues.map { |queue| "queue:#{queue}" }
+    # TODO thread interval from the worker
+    interval = 1
+    queue, payload = redis.blpop(*queue_names, interval)
+    queue && [queue.sub("#{redis.namespace}:queue:", ""), decode(payload)]
   end
 
   # Returns an integer representing the size of a queue.

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -332,8 +332,8 @@ module Resque
   # precise name of a queue: case matters.
   #
   # This method is considered part of the `stable` API.
-  def reserve(queue)
-    Job.reserve(queue)
+  def reserve(*queues)
+    Job.reserve(*queues)
   end
 
   # Validates if the given klass could be a valid Resque job

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -95,10 +95,15 @@ module Resque
       destroyed
     end
 
-    # Given a string queue name, returns an instance of Resque::Job
-    # if any jobs are available. If not, returns nil.
-    def self.reserve(*queues)
-      valid_queues = queues.select do |queue|
+    # Attempt to reserve a Resque::Job.
+    #
+    # queues  - An Array of String queue names to check
+    # timeout - Integer number of seconds to block when retrieving jobs.
+    #           Defaults to 1.
+    #
+    # Returns a Resque::Job or falsey.
+    def self.reserve(queues, timeout=1)
+      valid_queues = Array(queues).select do |queue|
         begin
           run_before_reserve_hook(queue)
           true
@@ -107,7 +112,7 @@ module Resque
         end
       end
       return if valid_queues.empty?
-      queue, payload = Resque.pop(*valid_queues)
+      queue, payload = Resque.pop(valid_queues, timeout)
       payload && new(queue, payload)
     end
 

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -99,10 +99,10 @@ module Resque
     #
     # queues  - An Array of String queue names to check
     # timeout - Integer number of seconds to block when retrieving jobs.
-    #           Defaults to 1.
+    #           Defaults to 5.
     #
     # Returns a Resque::Job or falsey.
-    def self.reserve(queues, timeout=1)
+    def self.reserve(queues, timeout=5)
       valid_queues = Array(queues).select do |queue|
         begin
           run_before_reserve_hook(queue)

--- a/lib/resque/server/test_helper.rb
+++ b/lib/resque/server/test_helper.rb
@@ -3,7 +3,7 @@ require 'resque/server'
 
 module Resque
   module TestHelper
-    class ActiveSupport::TestCase
+    class Test::Unit::TestCase
       include Rack::Test::Methods
       def app
         Resque::Server.new

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -129,7 +129,11 @@ module Resque
       loop do
         break if shutdown?
 
-        if not paused? and job = reserve(interval)
+        if !paused
+          procline "Waiting for #{@queues.join(',')}"
+        end
+
+        if !paused? && job = reserve(interval)
           log "got: #{job.inspect}"
           job.worker = self
           run_hook :before_fork, job
@@ -151,8 +155,8 @@ module Resque
           run_hook :after_perform, self
         else
           break if interval.zero? # for testing
-          procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
           if paused?
+            procline "Paused"
             sleep interval
           end
         end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -200,8 +200,8 @@ module Resque
     # nil if no job can be found.
     #
     # timeout - an Integer timeout in seconds to use for the blocking pop.
-    #           Defaults to 1.
-    def reserve(timeout=1)
+    #           Defaults to 5.
+    def reserve(timeout=5)
       if job = Resque.reserve(queues, timeout)
         log! "Found job on #{job.queue}"
         return job

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -129,7 +129,7 @@ module Resque
       loop do
         break if shutdown?
 
-        if !paused
+        if !paused?
           procline "Waiting for #{@queues.join(',')}"
         end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -115,21 +115,21 @@ module Resque
     # 2. Work loop: Jobs are pulled from a queue and processed.
     # 3. Teardown:  This worker is unregistered.
     #
-    # Can be passed a float representing the polling frequency.
+    # Can be passed an integer representing the polling frequency.
     # The default is 5 seconds, but for a semi-active site you may
     # want to use a smaller value.
     #
     # Also accepts a block which will be passed the job as soon as it
     # has completed processing. Useful for testing.
-    def work(interval = 5.0, &block)
-      interval = Float(interval)
+    def work(interval = 5, &block)
+      interval = Integer(interval)
       $0 = "resque: Starting"
       startup
 
       loop do
         break if shutdown?
 
-        if not paused? and job = reserve
+        if not paused? and job = reserve(interval)
           log "got: #{job.inspect}"
           job.worker = self
           run_hook :before_fork, job
@@ -150,10 +150,11 @@ module Resque
 
           run_hook :after_perform, self
         else
-          break if interval.zero?
-          log! "Sleeping for #{interval} seconds"
+          break if interval.zero? # for testing
           procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
-          sleep interval
+          if paused?
+            sleep interval
+          end
         end
       end
 
@@ -197,12 +198,14 @@ module Resque
 
     # Attempts to grab a job off one of the provided queues. Returns
     # nil if no job can be found.
-    def reserve
-      if job = Resque.reserve(*queues)
+    #
+    # timeout - an Integer timeout in seconds to use for the blocking pop.
+    #           Defaults to 1.
+    def reserve(timeout=1)
+      if job = Resque.reserve(queues, timeout)
         log! "Found job on #{job.queue}"
         return job
       end
-
       nil
     rescue Exception => e
       log "Error reserving job: #{e.inspect}"

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -198,12 +198,9 @@ module Resque
     # Attempts to grab a job off one of the provided queues. Returns
     # nil if no job can be found.
     def reserve
-      queues.each do |queue|
-        log! "Checking #{queue}"
-        if job = Resque.reserve(queue)
-          log! "Found job on #{queue}"
-          return job
-        end
+      if job = Resque.reserve(*queues)
+        log! "Found job on #{job.queue}"
+        return job
       end
 
       nil

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -342,6 +342,7 @@ context "Resque::Job before_dequeue" do
     Resque.dequeue(BeforeDequeueJob, history)
     @worker.work(0)
     assert_equal history, [:before_dequeue], "before_dequeue was not run"
+    assert_equal [:before_dequeue], history, "before_dequeue was not run"
   end
 
   test "a before dequeue hook that returns false should prevent the job from getting dequeued" do

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -341,7 +341,6 @@ context "Resque::Job before_dequeue" do
     @worker = Resque::Worker.new(:jobs)
     Resque.dequeue(BeforeDequeueJob, history)
     @worker.work(0)
-    assert_equal history, [:before_dequeue], "before_dequeue was not run"
     assert_equal [:before_dequeue], history, "before_dequeue was not run"
   end
 

--- a/test/job_plugins_test.rb
+++ b/test/job_plugins_test.rb
@@ -159,25 +159,6 @@ context "Resque::Plugin ordering around_perform" do
     end
   end
 
-  class ::AroundPerformJob3
-    extend AroundPerformPlugin1
-    extend AroundPerformPlugin2
-    extend AroundPerformDoesNotYield
-    def self.perform(history)
-      history << :perform
-    end
-    def self.around_perform(history)
-      history << :around_perform
-      yield
-    end
-  end
-
-  test "the job is aborted if an around_perform hook does not yield" do
-    result = perform_job(AroundPerformJob3, history=[])
-    assert_equal false, result, "perform returned false"
-    assert_equal [:around_perform, :around_perform0], history
-  end
-
   module AroundPerformGetsJobResult
     @@result = nil
     def last_job_result

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -163,20 +163,20 @@ context "Resque" do
   end
 
   test "can pull items off a queue" do
-    assert_equal({ 'name' => 'chris' }, Resque.pop(:people))
-    assert_equal({ 'name' => 'bob' }, Resque.pop(:people))
-    assert_equal({ 'name' => 'mark' }, Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'chris' }], Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'bob' }], Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'mark' }], Resque.pop(:people))
     assert_equal nil, Resque.pop(:people)
   end
 
   test "knows how big a queue is" do
     assert_equal 3, Resque.size(:people)
 
-    assert_equal({ 'name' => 'chris' }, Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'chris' }], Resque.pop(:people))
     assert_equal 2, Resque.size(:people)
 
-    assert_equal({ 'name' => 'bob' }, Resque.pop(:people))
-    assert_equal({ 'name' => 'mark' }, Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'bob' }], Resque.pop(:people))
+    assert_equal(["people", { 'name' => 'mark' }], Resque.pop(:people))
     assert_equal 0, Resque.size(:people)
   end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -199,7 +199,7 @@ context "Resque" do
   test "knows what queues it is managing" do
     assert_equal %w( people ), Resque.queues
     Resque.push(:cars, { 'make' => 'bmw' })
-    assert_equal %w( cars people ), Resque.queues
+    assert_equal %w( cars people ), Resque.queues.sort
   end
 
   test "queues are always a list" do
@@ -209,7 +209,7 @@ context "Resque" do
 
   test "can delete a queue" do
     Resque.push(:cars, { 'make' => 'bmw' })
-    assert_equal %w( cars people ), Resque.queues
+    assert_equal %w( cars people ), Resque.queues.sort
     Resque.remove_queue(:people)
     assert_equal %w( cars ), Resque.queues
     assert_equal nil, Resque.pop(:people)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -233,41 +233,6 @@ context "Resque::Worker" do
     end
   end
 
-  test "keeps track of how many jobs it has processed" do
-    Resque::Job.create(:jobs, BadJob)
-    Resque::Job.create(:jobs, BadJob)
-
-    3.times do
-      job = @worker.reserve
-      @worker.process job
-    end
-    assert_equal 3, @worker.processed
-  end
-
-  test "keeps track of how many failures it has seen" do
-    Resque::Job.create(:jobs, BadJob)
-    Resque::Job.create(:jobs, BadJob)
-
-    3.times do
-      job = @worker.reserve
-      @worker.process job
-    end
-    assert_equal 2, @worker.failed
-  end
-
-  test "stats are erased when the worker goes away" do
-    @worker.work(0)
-    assert_equal 0, @worker.processed
-    assert_equal 0, @worker.failed
-  end
-
-  test "knows when it started" do
-    time = Time.now
-    @worker.work(0) do
-      assert_equal time.to_s, @worker.started.to_s
-    end
-  end
-
   test "knows whether it exists or not" do
     @worker.work(0) do
       assert Resque::Worker.exists?(@worker)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -162,7 +162,7 @@ context "Resque::Worker" do
   end
 
   test "has a unique id" do
-    assert_equal "#{`hostname`.chomp}:#{$$}:jobs", @worker.to_s
+    assert_equal "#{`hostname`.chomp}:#{$$}", @worker.to_s
   end
 
   test "complains if no queues are given" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -263,7 +263,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "cleans up dead worker info on start (crash recovery)" do
+  test "cleans up dead worker when requested" do
     # first we fake out two dead workers
     workerA = Resque::Worker.new(:jobs)
     workerA.instance_variable_set(:@to_s, "#{`hostname`.chomp}:1:jobs")
@@ -276,6 +276,7 @@ context "Resque::Worker" do
     assert_equal 2, Resque.workers.size
 
     # then we prune them
+    @worker.prune_dead_workers
     @worker.work(0) do
       assert_equal 1, Resque.workers.size
     end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -317,6 +317,7 @@ context "Resque::Worker" do
   end
 
   test "worker_pids returns pids" do
+    @worker.work(0) # to set a findable procline
     known_workers = @worker.worker_pids
     assert !known_workers.empty?
   end


### PR DESCRIPTION
This PR changes how workers reserve jobs from LPOP in a loop to a single blocking BLPOP for all queues simultaneously.

## Background

As the number of workers and the number of distinct queues grows, we're seeing higher and higher command counts against the redis server, as well as the associated CPU usage to process them. After recent changes (#10 and a change internal to the github app) the overall number of commands has been significantly reduced, leaving one high-volume standout: `LPOP`. Resque uses `LPOP` in the worker code when trying to reserve jobs. In short:

* For every queue:
    * `LPOP` to reserve a job
    * If a job is found, process it and start over
    * If no job found, continue to next queue
* If no job was found in all the queues, sleep for a default of 5 seconds before trying again.

At a minimum, this means we're issuing `N workers * M queues` LPOPs every five seconds, and for every worker that processes a job, that five second sleep is skipped as the polling loop starts again.

## `BLPOP`

My primary goal was to eliminate the multiple commands when reserving jobs for multiple queues. I had hoped that `LPOP` would take more than one `<key>` argument, but it was not to be. The only left-pop command available with multiple key support is `BLPOP`, a blocking pop.

Fortunately, changing from polling to blocking isn't a major semantic difference -- there's little functional difference between busy-poll then sleep, versus block on all queues with a timeout matching the sleep interval.

`BLPOP` preserves the ordering behavior required by resque. Where resque would `LPOP` in queue order -- `LPOP q1`, `LPOP q2`, `LPOP q3` and process the job it got first -- `BLPOP q1 q2 q3` will also get the job that shows up on `q1` before it gets the one on `q3`.

The resque code sleeps for 5 seconds after polling its queues. In theory this would give redis a break, and it also gives resque a chance to reexamine its queue list in the case of workers running on `*` queues, where list is refreshed on every iteration. Changing to blocking doesn't affect this, either: I've preserved the 5-second sleep in the form of a 5-second timeout on the `BLPOP`, so resque will still loop and refresh its queue list every 5 seconds. (N.B. we don't use `*` in production, favoring explicit queue lists, but we do use wildcard queues in development.)

## Tradeoffs

While I expect this to dramatically reduce the number of commands executed against the redis server and the associated CPU usage, it's possible that the overhead of `BLPOP` will counterbalance in terms of resource usage. This PR replaces `n O(1)` operations with a single `O(n)` operation, resulting in at least reduced network/command overhead. It's possible, however, that the bookkeeping redis does internally to track all its blocking clients and queues will cause an increase in CPU usage on the redis server.

As a result, I'm going to use CPU reduction as the primary success criteria for using this branch of redis in the github application, rather than total command count, since total commands will be reduced regardless.

A potential benefit of using a blocking pop is that for quiet queues or mostly idle workers, it will guarantee faster response for newly queued jobs. Whereas before, idle workers would spend most of their time sleeping, they'll now be blocking and will immediately receive and start processing any newly queued job. I don't expect this to have a measurable effect in our production environment since we keep our workers pretty busy, but want to note it here as a possible improvement.

## Changes

The bulk of this PR, 9583c7a...476c3d9 and dbeb57a, were basic fixes and cleanups to get the test suite working again. It seems we've been changing resque without test support for a while, and this change is significant enough that I didn't feel comfortable continuing that practice without support.

3cc10fb and 30425e4...d594ce8 do the refactoring to replace LPOP with BLPOP.

cc @ammeep @github/background-jobs @github/high-availability