### PR TITLE
Fix empty queue busy wait

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -103,7 +103,6 @@ module Resque
     #
     # Returns a Resque::Job or falsey.
     def self.reserve(queues, timeout=5)
-      queues = reservable_queues(queues)
       return if queues.empty?
       queue, payload = Resque.pop(queues, timeout)
       payload && new(queue, payload)


### PR DESCRIPTION
@charliesome noted an unintended side effect of using `BLPOP` (#11): if no queues are available, resque workers will spin and consume CPU. Because the BLPOP branch removed any "sleep if no job was reserved" code, and if no queues are available for reservations (either because `redis:queues` is empty still, or because no queues have passed their `before_reserve`hooks), the worker will loop and retry without pausing.

This PR is a little hacky, but it gets the job done:

* I've extracted the "reservable queues" filter from `Job.reserve`, so it can be retrieved and checked elsewhere
* In `Worker#reserve`, I retrieve the reservable queues, and if it's empty, `sleep` rather than immediately returning.