### PR TITLE
Worker id must include a queue

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -463,7 +463,7 @@ module Resque
     # The string representation is the same as the id for this worker
     # instance. Can be used with `Worker.find`.
     def to_s
-      @to_s ||= "#{hostname}:#{Process.pid}:"
+      @to_s ||= "#{hostname}:#{Process.pid}:-"
     end
     alias_method :id, :to_s
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -463,7 +463,7 @@ module Resque
     # The string representation is the same as the id for this worker
     # instance. Can be used with `Worker.find`.
     def to_s
-      @to_s ||= "#{hostname}:#{Process.pid}"
+      @to_s ||= "#{hostname}:#{Process.pid}:"
     end
     alias_method :id, :to_s
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -162,7 +162,7 @@ context "Resque::Worker" do
   end
 
   test "has a unique id" do
-    assert_equal "#{`hostname`.chomp}:#{$$}:", @worker.to_s
+    assert_equal "#{`hostname`.chomp}:#{$$}:-", @worker.to_s
   end
 
   test "complains if no queues are given" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -162,7 +162,7 @@ context "Resque::Worker" do
   end
 
   test "has a unique id" do
-    assert_equal "#{`hostname`.chomp}:#{$$}", @worker.to_s
+    assert_equal "#{`hostname`.chomp}:#{$$}:", @worker.to_s
   end
 
   test "complains if no queues are given" do


### PR DESCRIPTION
So the workers using this branch don't confuse (read: break) resque workers that are sharing the same infrastructure but not this code, and which are expecting a three-part worker id.

We have a small number of resque workers sharing our resque redis infrastructure, but which are running "vanilla" resque rather than this customized branch. However, the shortened/simplified worker ids introduced in #10 break regular redis workers which are expecting a three-part `hostname:pid:list,of,queues` identifier rather than `hostname:pid`.

This branch fixes it by adding back an empty third part of a worker id, that is: `hostname:pid:-` -- which is interpreted as a single queue `["-"]`. It's not empty because `Worker.find` will raise if the list of queues is entirely empty, so a minimal and clearly not-normally-valid queue name of `-` is a part of the id.

Here's the error:

```
irb> Resque::Worker.all
NoMethodError: undefined method `split' for nil:NilClass
	from /path/to/app/vendor/gems/ruby/2.2.0/gems/resque-1.26.0/lib/resque/worker.rb:93:in `find'
	from /path/to/app/vendor/gems/ruby/2.2.0/gems/resque-1.26.0/lib/resque/worker.rb:56:in `block in all'
	from /path/to/app/vendor/gems/ruby/2.2.0/gems/resque-1.26.0/lib/resque/worker.rb:56:in `map'
	from /path/to/app/vendor/gems/ruby/2.2.0/gems/resque-1.26.0/lib/resque/worker.rb:56:in `all'
	from (irb):3
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/cli.rb:611:in `console'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/vendor/thor/task.rb:27:in `run'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/vendor/thor.rb:344:in `dispatch'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/vendor/thor/base.rb:434:in `start'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/bin/bundle:20:in `block in <top (required)>'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/lib/bundler/friendly_errors.rb:4:in `with_friendly_errors'
	from /usr/share/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/bundler-1.3.0/bin/bundle:20:in `<top (required)>'
	from /usr/share/rbenv/versions/2.2.3/bin/bundle:23:in `load'
	from /usr/share/rbenv/versions/2.2.3/bin/bundle:23:in `<main>'
```

cc @github/high-availability @github/background-jobs 