### PR TITLE
Add pipelined around push and remove_queue

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -167,8 +167,10 @@ module Resque
   #
   # Returns nothing
   def push(queue, item)
-    watch_queue(queue)
-    redis.rpush "queue:#{queue}", encode(item)
+    redis.pipelined do
+      watch_queue(queue)
+      redis.rpush "queue:#{queue}", encode(item)
+    end
   end
 
   # Pops a job off one ore more queues.
@@ -223,8 +225,10 @@ module Resque
 
   # Given a queue name, completely deletes the queue.
   def remove_queue(queue)
-    redis.srem(:queues, queue.to_s)
-    redis.del("queue:#{queue}")
+    redis.pipelined do
+      redis.srem(:queues, queue.to_s)
+      redis.del("queue:#{queue}")
+    end
   end
 
   # Used internally to keep track of which queues we've created.
@@ -411,4 +415,3 @@ module Resque
     end
   end
 end
-


### PR DESCRIPTION
@zerowidth got most of these in https://github.com/github/resque/pull/10. In an effort to drop some network calls around enqueueing in particular, this push with pipelining. [Plucked from upstream](https://github.com/resque/resque/pull/902/files) the one other spot we weren't pipelining (`remove_queue` ... because why not). 

cc @zerowidth @janester for review
fyi @ammeep 