### PR TITLE
Reserve from available queues

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -216,7 +216,7 @@ module Resque
       available_queues = Job.reservable_queues(queues)
       if available_queues.empty?
         sleep timeout # prevent busy-wait.
-      elsif job = Job.reserve(queues, timeout)
+      elsif job = Job.reserve(available_queues, timeout)
         log! "Found job on #{job.queue}"
         return job
       end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -375,7 +375,7 @@ context "Resque::Worker" do
     Resque.before_reserve do |queue|
       raise Resque::Job::DontReserve if queue == "jobs"
     end
-    worker = Resque::Worker.new(:jobs)
+    worker = Resque::Worker.new(:jobs, :more_jobs)
     worker.work(0)
     assert_equal 1, Resque.size(:jobs)
   end


### PR DESCRIPTION
In #12, `Worker#reserve` was refactored to check the list of reservable queues, and sleep if the list was empty. If at least one queue is available though, the entire list of queues is passed to `Job.reserve`, making a `before_reserve` hook ineffective if a worker is serving two or more queues.

Adding a second queue to the `before_reserve` test shows the failure:

```
  1) Failure:
#<Class:0x0055ec1e126f50>#test_before_reserve_hook_can_stop_a_worker_from_pulling_from_queue [/root/resque/test/worker_test.rb:380]:
<1> expected but was
<0>.
```

Handing just the list of available queues to `Job.reserve` fixes the issue.