### PR TITLE
Update to latest version of redis-namespace

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -185,7 +185,7 @@ module Resque
     queue_names = Array(queues).map { |queue| "queue:#{queue}" }
     timeout = [1, timeout].max # require nonzero, no infinite blocking
     queue, payload = redis.blpop(*queue_names, timeout)
-    queue && [queue.sub("#{redis.namespace}:queue:", ""), decode(payload)]
+    queue && [queue.sub("queue:", ""), decode(payload)]
   end
 
   # Returns an integer representing the size of a queue.

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.0.2"
+  s.add_dependency "redis-namespace", "~> 1.3"
   s.add_dependency "vegas",           "~> 0.1.2"
   s.add_dependency "sinatra",         ">= 0.9.2"
   s.add_dependency "multi_json",      "~> 1.0"


### PR DESCRIPTION
This is to unblock being able to move to the latest Redis client gem. 