### PR TITLE
Add generalized retry logic for Redis operations

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -83,13 +83,14 @@ module Resque
       destroyed = 0
 
       if args.empty?
-        redis.lrange(queue, 0, -1).each do |string|
+        items = with_retries { redis.lrange(queue, 0, -1) }
+        items.each do |string|
           if decode(string)['class'] == klass
-            destroyed += redis.lrem(queue, 0, string).to_i
+            destroyed += with_retries { redis.lrem(queue, 0, string).to_i }
           end
         end
       else
-        destroyed += redis.lrem(queue, 0, encode(:class => klass, :args => args))
+        destroyed += with_retries { redis.lrem(queue, 0, encode(:class => klass, :args => args)) }
       end
 
       destroyed

--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -24,7 +24,9 @@ module Resque
     # Can optionally accept a second int parameter. The stat is then
     # incremented by that amount.
     def incr(stat, by = 1)
-      redis.incrby("stat:#{stat}", by)
+      with_retries do
+        redis.incrby("stat:#{stat}", by)
+      end
     end
 
     # Increments a stat by one.
@@ -37,7 +39,9 @@ module Resque
     # Can optionally accept a second int parameter. The stat is then
     # decremented by that amount.
     def decr(stat, by = 1)
-      redis.decrby("stat:#{stat}", by)
+      with_retries do
+        redis.decrby("stat:#{stat}", by)
+      end
     end
 
     # Decrements a stat by one.
@@ -47,7 +51,9 @@ module Resque
 
     # Removes a stat from Redis, effectively setting it to 0.
     def clear(stat)
-      redis.del("stat:#{stat}")
+      with_retries do
+        redis.del("stat:#{stat}")
+      end
     end
   end
 end


### PR DESCRIPTION
This moves the Redis logic to be more generally retried instead of only the `blpop`. I've looked at each of these cases and it should be safe to retry these. I've make sure to retry individual operations and not larger blocks in case a retry is needed mid way during an operation requiring multiple steps. 