### PR TITLE
Add option to make worker handle SIGTERM by marking job for termination but allowing completion of current job.

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -15,6 +15,7 @@ namespace :resque do
       worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       worker.very_verbose = ENV['VVERBOSE']
       worker.cant_fork = true if ENV['FORK_PER_JOB'] == 'false'
+      worker.graceful_term = ENV['GRACEFUL_TERM']
     rescue Resque::NoQueueError
       abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
     end


### PR DESCRIPTION
This makes the worker terminate gracefully in environments (e.g. Kubernetes) that issue a SIGTERM as a warning before issuing a SIGKILL. This is a step along the way towards getting our notification delivery jobs to run robustly in Kube (https://github.com/github/github/issues/117490). It also mirrors a similar change made to the `resque/resque` upstream in https://github.com/resque/resque/pull/1007.

I'm open to feedback as to if it is necessary to test this. I could neither figure out a good way to do or find a precedent in the existing tests, and the change seemed straightforward enough not to worry to much about it. I have tested locally that this works as expected (by symlinking this version into `github/github` and testing a normal job).

cc @dbussink and/or @zerowidth for review please (I guessed based on commit history that you would be the people most familiar with this codebase).