### PR TITLE
In worker, retry forever with an exponential back off when Redis interactions time out

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -185,7 +185,7 @@ module Resque
   def pop(queues, timeout = 1, retries = 3)
     queue_names = Array(queues).map { |queue| "queue:#{queue}" }
     timeout = [1, timeout].max # require nonzero, no infinite blocking
-    with_retries(max_retries: retries) do
+    with_retries(retries: retries) do
       queue, payload = redis.blpop(*queue_names, timeout)
       queue && [queue.sub("queue:", ""), decode(payload)]
     end

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -185,7 +185,7 @@ module Resque
   def pop(queues, timeout = 1, retries = 3)
     queue_names = Array(queues).map { |queue| "queue:#{queue}" }
     timeout = [1, timeout].max # require nonzero, no infinite blocking
-    with_retries(retries: retries) do
+    with_retries(max_retries: retries) do
       queue, payload = redis.blpop(*queue_names, timeout)
       queue && [queue.sub("queue:", ""), decode(payload)]
     end

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -88,7 +88,7 @@ module Resque
       #  * We failover through a proxy layer.
       #  * Redis accepts connections but does not respond, which can happen
       #    if Redis CPU utilization is high.
-      if retries > 0
+      while retries > 0
         retries -= 1
         # Wait for a random time between 0 and 1 second to prevent thundering
         # reconnect herd

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -84,19 +84,19 @@ module Resque
       yield
     rescue Redis::TimeoutError => e
       # This exception happens when
-      #  * Redis goes away
+      #  * Redis goes away.
       #  * We failover through a proxy layer.
       #  * Redis accepts connections but does not respond, which can happen
       #    if Redis CPU utilization is high.
-      #
-      # Wait for a random time between 0 and 1 second to prevent thundering reconnect herd
-      sleep rand
-      if retries > 0 && Resque.reconnect(1)
+      if retries > 0
         retries -= 1
-        retry
-      else
-        raise e
+        # Wait for a random time between 0 and 1 second to prevent thundering
+        # reconnect herd
+        sleep rand
+        retry if Resque.reconnect(1)
       end
+
+      raise e
     end
   end
 end

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -99,7 +99,7 @@ module Resque
         #  * We failover through a proxy layer.
         #  * Redis accepts connections but does not respond, which can happen
         #    if Redis CPU utilization is high.
-        connected = false
+        reconnected = false
         while retry_forever? || retries < max_retries
           if back_off_on_retry?
             # Wait for a random time plus a jittery exponential backoff to
@@ -111,12 +111,12 @@ module Resque
 
           retries += 1
           if Resque.reconnect(1)
-            connected = true
+            reconnected = true
             break
           end
         end
 
-        if connected
+        if reconnected
           retry
         else
           raise e

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -102,8 +102,8 @@ module Resque
         reconnected = false
         while retry_forever? || retries < max_retries
           if back_off_on_retry?
-            # Wait for a random time plus a jittery exponential backoff to
-            # reduce thundering reconnect herds.
+            # Wait for a jittery exponential backoff to reduce thundering
+            # reconnect herds.
             sleep [2 ** retries + (rand * 5), 60].min
           else
             sleep rand

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -80,6 +80,14 @@ module Resque
       constant
     end
 
+    def retry_forever?
+      false
+    end
+
+    def back_off_on_retry?
+      false
+    end
+
     def with_retries(max_retries: 3)
       retries = 0
       begin
@@ -92,10 +100,15 @@ module Resque
         #  * Redis accepts connections but does not respond, which can happen
         #    if Redis CPU utilization is high.
         connected = false
-        while retries < max_retries
-          # Wait for a random time plus an exponetial backoff to reduce
-          # thundering reconnect herds
-          sleep (3 ** retries) + rand
+        while retry_forever? || retries < max_retries
+          if back_off_on_retry?
+            # Wait for a random time plus a jittery exponential backoff to
+            # reduce thundering reconnect herds.
+            sleep [2 ** retries + (rand * 5), 60].min
+          else
+            sleep rand
+          end
+
           retries += 1
           if Resque.reconnect(1)
             connected = true

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -81,18 +81,21 @@ module Resque
     end
 
     def with_retries(retries: 3)
-      begin
-        yield
-      rescue Redis::TimeoutError => e
-        # This exception happens when Redis goes
-        # away or we failover through a proxy layer.
-        # Wait for a random time between 0 and 1 second to prevent thundering reconnect herd
-        sleep rand
-        if Resque.reconnect(retries)
-          retry
-        else
-          raise e
-        end
+      yield
+    rescue Redis::TimeoutError => e
+      # This exception happens when
+      #  * Redis goes away
+      #  * We failover through a proxy layer.
+      #  * Redis accepts connections but does not respond, which can happen
+      #    if Redis CPU utilization is high.
+      #
+      # Wait for a random time between 0 and 1 second to prevent thundering reconnect herd
+      sleep rand
+      if retries > 0 && Resque.reconnect(1)
+        retries -= 1
+        retry
+      else
+        raise e
       end
     end
   end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -107,6 +107,20 @@ module Resque
       validate_queues
     end
 
+    # Configure `with_retries` helper to never fail retrying Redis, but
+    # instead to keep retrying until the worker is explicitly shut down. We
+    # enable exponential back off for these retries, and want to prevent the
+    # worker from failing, because Resqued will just restart it and reset our
+    # exponential back-off back to zero.
+    def retry_forever?
+      !shutdown?
+    end
+
+    # See comment on retry_forever? method above.
+    def back_off_on_retry?
+      true
+    end
+
     # A worker must be given a queue, otherwise it won't know what to
     # do with itself.
     #

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -186,6 +186,7 @@ context "Resque" do
   end
 
   test "limits retries when popping off items" do
+    Resque.stubs(:sleep)
     Resque.redis.stubs(:blpop).raises(Redis::TimeoutError, "connection reset")
     assert_raises Redis::TimeoutError do
       Resque.pop(:people)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -166,3 +166,29 @@ class Time
     alias_method :now, :now_with_mock_time
   end
 end
+
+class FakeRedis
+  def get(key)
+  end
+
+  def on_set(&block)
+    @on_set = block
+  end
+
+  def set(key, value)
+    @on_set.call(key, value) if @on_set
+  end
+
+  def srem(key, value)
+  end
+
+  def sadd(key, value)
+  end
+
+  def del(key)
+  end
+
+  def pipelined
+    yield
+  end
+end


### PR DESCRIPTION
Currently, when we time out talking to Redis, we reconnect and retry the operation. For a fail-over scenario where the Redis server has moved to a new host, this behavior works. For scenarios in which the Redis is still available but is overwhelmed with load, repeatedly reconnecting and retrying operations has the potential to make the situation worse.

In this PR, I introduce `Worker#with_exponential_backoff` and use it in the `Worker` instead of `with_retries`.

* When retrying, exponentially back off by powers of 2, up to a maximum of 60 seconds, with 5 seconds of random jitter.
* Continue retrying forever until the worker is explicitly shut down. This prevents a scenario where the worker process dies after N attempts only to be restarted by Resqued. This ensures that we continue to retry at a reduced frequency until Redis service health recovers. Restarting the process would cause us to start retrying at a faster rate.

I limit these changes to the worker because backing off and retrying forever in Unicorn processes when enqueuing jobs could cause request timeouts.

I also change the behavior of `with_retries` slightly so that attempts to reconnect also count as a retry attempt. The existing logic can end up trying to reconnect up to 9 times in certain scenarios.