### PR TITLE
Limit retries when they happen outside of reconnects

### DIFF
--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -185,6 +185,14 @@ context "Resque" do
     Resque.redis.unstub(:blpop)
   end
 
+  test "limits retries when popping off items" do
+    Resque.redis.stubs(:blpop).raises(Redis::TimeoutError, "connection reset")
+    assert_raises Redis::TimeoutError do
+      Resque.pop(:people)
+    end
+    Resque.redis.unstub(:blpop)
+  end
+
   test "knows how big a queue is" do
     assert_equal 3, Resque.size(:people)
 


### PR DESCRIPTION
The reconnect logic here assumed that if we retry the command, it will succeed if we're able to reconnect to Redis. This is not the case in the following scenario and in that case we want to make sure to raise the
original exception here and not retry infinitely.

- Redis is swamped with work and can't keep up
- Commands to Redis timeout
- Reconnects still succeed as the kernel is able to accept the TCP connection
- Since the reconnect does succeed, the logic here will end up in an infinite loop retrying the Redis command. This actually makes the problem in step 1 here worse.