### PR TITLE
Remove bookkeeping

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -415,11 +415,11 @@ module Resque
   def info
     return {
       :pending   => queues.inject(0) { |m,k| m + size(k) },
-      :processed => Stat[:processed],
+      :processed => 0,
       :queues    => queues.size,
       :workers   => workers.size.to_i,
       :working   => working.size,
-      :failed    => Stat[:failed],
+      :failed    => 0,
       :servers   => [redis_id],
       :environment  => ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     }

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -177,7 +177,6 @@ module Resque
         rescue Object => e
           log "Received exception when reporting failure: #{e.inspect}"
         end
-        Stat << "failed"
       else
         log "done: #{job.inspect}"
       ensure
@@ -390,7 +389,6 @@ module Resque
     # and tells Redis we processed a job.
     def done_working
       @current_job = nil
-      Stat << "processed"
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -260,16 +260,10 @@ context "Resque" do
     assert_equal 8, stats[:pending]
 
     @worker = Resque::Worker.new(:jobs)
-    @worker.register_worker
     2.times { @worker.process }
 
     job = @worker.reserve
     @worker.working_on job
-
-    stats = Resque.info
-    assert_equal 1, stats[:working]
-    assert_equal 1, stats[:workers]
-
     @worker.done_working
 
     stats = Resque.info

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -268,8 +268,6 @@ context "Resque" do
 
     stats = Resque.info
     assert_equal 3, stats[:queues]
-    assert_equal 3, stats[:processed]
-    assert_equal 1, stats[:failed]
     if ENV.key? 'RESQUE_DISTRIBUTED'
       assert_equal [Resque.redis.respond_to?(:server) ? 'localhost:9736, localhost:9737' : 'redis://localhost:9736/0, redis://localhost:9737/0'], stats[:servers]
     else

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -223,11 +223,6 @@ context "Resque::Worker" do
     assert !known_workers.empty?
   end
 
-  test "Processed jobs count" do
-    @worker.work(0)
-    assert_equal 1, Resque.info[:processed]
-  end
-
   test "Will call a before_first_fork hook only once" do
     reset_resque
     $BEFORE_FORK_CALLED = 0


### PR DESCRIPTION
This PR removes the worker and success/failure bookkeeping, to reduce the overall number of operations against redis.